### PR TITLE
Fix: cors for assets

### DIFF
--- a/standalone/src/index.js
+++ b/standalone/src/index.js
@@ -391,6 +391,11 @@ const api = new Elysia({ prefix: "/:key" })
   });
 
 const assetsServer = new Elysia({ prefix: "/assets" })
+  .use(
+    cors({
+      origin: process.env.CORS_ORIGIN || true,
+    })
+  )  
   .get("/widget.js", ({ set }) => {
     set.headers["Content-Type"] = "text/javascript";
     return file(path.join(dataDir, "assets-widget.js"));


### PR DESCRIPTION
## Context

We should also allow `assets` to be `CORS`, use the same policy as `/api`