### PR TITLE
Fix header access in ratelimitGenerator to support Headers object API

### DIFF
--- a/standalone/src/ratelimit.js
+++ b/standalone/src/ratelimit.js
@@ -1,7 +1,7 @@
 export const ratelimitGenerator = (req, server) => {
   if (process.env.RATELIMIT_IP_HEADER) {
     const header = process.env.RATELIMIT_IP_HEADER;
-    const ip = req.headers[header] || req.headers[header.toLowerCase()];
+    const ip = req.headers[header] || req.headers.get(header.toLowerCase());
 
     if (ip) {
       return ip.split(",")[0].trim();


### PR DESCRIPTION
This PR updates the `ratelimitGenerator` function to correctly access headers when `req.headers` is a [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers).

### Changes
  ```js
    req.headers[header.toLowerCase()]
  ```
  with:
  ```js
    req.headers.get(header.toLowerCase())
  ```

### Reason
The original code assumes req.headers is a plain object, but in environments where it is a Headers instance, direct property access returns undefined.
