### PR TITLE
Time duration selection box is not displaying properly

### DIFF
--- a/standalone/public/index.css
+++ b/standalone/public/index.css
@@ -492,7 +492,7 @@ nav .logout:hover {
   border: none;
   border-radius: 6px;
   color: white;
-  background-color: transparent;
+  background-color: #181818;
   padding: 0px;
   font-family: inherit;
   cursor: pointer;


### PR DESCRIPTION
The time duration selection box is not displaying properly due to the transparent colour setting.

Before
<img width="149" height="205" alt="image" src="https://github.com/user-attachments/assets/1b5f2202-23ff-4d2c-85ff-d8fd425e2fd4" />

After
<img width="171" height="222" alt="image" src="https://github.com/user-attachments/assets/5ddf5436-b8dd-49f4-b0aa-93ff5bd704d1" />
