### PR TITLE
Allow to customize port and hostname for standalone server

### DIFF
--- a/docs/guide/standalone.md
+++ b/docs/guide/standalone.md
@@ -37,6 +37,11 @@ Then, you can access the dashboard at `http://localhost:3000`, log in, and creat
 
 You can change the default CORS settings for redeeming tokens, generating challenges and serving assets by setting the `CORS_ORIGIN` environment variable when running the server. This defaults to `*`, which allows all origins. This will directly assign to Access-Control-Allow-Origin header.
 
+### Hostname and port
+
+You can change the default port and hostname by setting the `SERVER_PORT` and `SERVER_HOSTNAME` environment variables when running the server. This defaults are `0.0.0.0` for hostname and `3000` for port.
+If you change port or hostname, you need to adapt Docker's port forwarding.
+
 ## Usage
 
 ### Client-side

--- a/standalone/src/index.js
+++ b/standalone/src/index.js
@@ -6,7 +6,15 @@ import { auth } from "./auth.js";
 import { capServer } from "./cap.js";
 import { server } from "./server.js";
 
-new Elysia()
+const serverPort = process.env.SERVER_PORT || 3000;
+const serverHostname = process.env.SERVER_HOSTNAME || '0.0.0.0'
+
+new Elysia({
+	serve: {
+		port: serverPort,
+		hostname: serverHostname
+	},
+})
 	.use(
 		swagger({
 			scalarConfig: {
@@ -60,6 +68,6 @@ new Elysia()
 	.use(server)
 	.use(assetsServer)
 	.use(capServer)
-	.listen(3000);
+	.listen(serverPort);
 
-console.log(`🧢 Cap running on http://localhost:3000`);
+console.log(`🧢 Cap running on http://${serverHostname}:${serverPort}`);


### PR DESCRIPTION
Currently, the standalone server is configured to listen on host 0.0.0.0 and port 3000 in a fixed manner. This configuration can be restrictive in environments that do not use Docker, for example when launching directly with the bun binary or after compiling the application (https://elysiajs.com/patterns/deploy.html#compile-to-binary). It may be necessary to choose a different port to avoid conflicts or to specify a particular network interface.

I'd like to propose a change that allows you to configure the port and hostname via environment variables.

The default behavior remains unchanged. If these variables are not set, the server will start as before at 0.0.0.0:3000. This change is therefore fully backward compatible and will not affect existing configurations, particularly those based on Docker.

To start the server with other hostname and port : `SERVER_HOSTNAME=127.0.0.1 SERVER_PORT=8000 ADMIN_KEY=changemeveryveryveryfastfastfast bun run src/index.js`