### PR TITLE
Add Hooks section to community guide

### DIFF
--- a/docs/guide/community.md
+++ b/docs/guide/community.md
@@ -18,7 +18,7 @@ These are wrappers around Cap's widget. They're usually not required as the defa
 
 These are React hook implementations of the Cap API, allowing full customization of the user experience.
 
-- **[@takeshape/use-cap]([https://npmjs](https://www.npmjs.com/package/@takeshape/use-cap)**
+- **[@takeshape/use-cap](https://www.npmjs.com/package/@takeshape/use-cap)**
 
 ## Server
 


### PR DESCRIPTION
We needed a fully customizable interface for some projects, and ended up developing a React Hook implementation of Cap.js. Adding a section to the community docs section for those who might find it useful.