### PR TITLE
Add capjs-server to community Python libraries

### DIFF
--- a/docs/guide/community.md
+++ b/docs/guide/community.md
@@ -56,6 +56,7 @@ These are React hook implementations of the Cap API, allowing full customization
 
 ### Python
 
+- **[capjs-server](https://github.com/vshn/capjs-server)**: Stateless Python server library for Cap token verification (no database required)
 - **[django-cap](https://pypi.org/project/django-cap/)**: Python implementation for Cap's server with Django
 
 ### .NET


### PR DESCRIPTION
## Summary

- Add [vshn/capjs-server](https://github.com/vshn/capjs-server) to the Python section of the community libraries page

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)