### PR TITLE
Fix floating button offsetted wrong in position: absolute parent

### DIFF
--- a/widget/src/src/cap-floating.js
+++ b/widget/src/src/cap-floating.js
@@ -19,7 +19,6 @@
 
     const offset = parseInt(element.getAttribute("data-cap-floating-offset")) || 8;
     const position = element.getAttribute("data-cap-floating-position") || "top";
-    const rect = element.getBoundingClientRect();
 
     Object.assign(capWidget.style, {
       display: "block",
@@ -39,22 +38,27 @@
       capWidget.style.marginTop = "0";
     }, 5);
 
-    const centerX = rect.left + (rect.width - capWidget.offsetWidth) / 2;
-    const safeX = Math.min(centerX, window.innerWidth - capWidget.offsetWidth);
+    // `position: absolute` is resolved against the nearest positioned ancestor (capWidget.offsetParent),
+    // but getBoundingClientRect() returns viewport-relative coords, convert to container-relative coords.
+    const triggerRect = element.getBoundingClientRect();
+    const containerRect = (capWidget.offsetParent ?? document.documentElement).getBoundingClientRect();
 
+    // Horizontally center the popup under the trigger button.
+    const centeredLeft = triggerRect.left + (triggerRect.width - capWidget.offsetWidth) / 2;
+    const clampedLeft = Math.max(2, Math.min(centeredLeft, window.innerWidth - capWidget.offsetWidth));
+    capWidget.style.left = `${clampedLeft - containerRect.left}px`;
+
+    // Place the popup above or below the trigger, clamped to the visible area.
     if (position === "top") {
-      capWidget.style.top = `${Math.max(
-        window.scrollY,
-        rect.top - capWidget.offsetHeight - offset + window.scrollY,
-      )}px`;
+      const idealTop = triggerRect.top - capWidget.offsetHeight - offset;
+      const clampedTop = Math.max(0, idealTop);
+      capWidget.style.top = `${clampedTop - containerRect.top}px`;
     } else {
-      capWidget.style.top = `${Math.min(
-        rect.bottom + offset + window.scrollY,
-        window.innerHeight - capWidget.offsetHeight + window.scrollY,
-      )}px`;
+      const idealTop = triggerRect.bottom + offset;
+      const clampedTop = Math.min(idealTop, window.innerHeight - capWidget.offsetHeight);
+      capWidget.style.top = `${clampedTop - containerRect.top}px`;
     }
 
-    capWidget.style.left = `${Math.max(safeX, 2)}px`;
     capWidget.solve();
 
     capWidget.addEventListener("solve", ({ detail }) => {


### PR DESCRIPTION
Offset is wrong when the button is placed inside a parent with `position: absolute`.
<img width="772" height="369" alt="image" src="https://github.com/user-attachments/assets/57204de9-b579-4746-95a3-cb2fe4c99996" />

After fix:
<img width="576" height="270" alt="image" src="https://github.com/user-attachments/assets/3873fc4b-7e58-44d3-a54b-5c15ae0459b9" />
<img width="541" height="169" alt="image" src="https://github.com/user-attachments/assets/3d9ab6c9-d692-49d6-9234-13f25fe77ba6" />


Recreate:
```html
<style>
    .offsetted {
        position: absolute;
        top: 100;
        left: 200;
    }
</style>

<form class="offsetted">
    <div>
        <cap-widget id="floating" required onsolve="console.log(`token: ${event.detail.token}`)"
            data-cap-api-endpoint="/wp-json/maoken-social/v1/cap/"></cap-widget>

        <button data-cap-floating="#floating" data-cap-floating-position="bottom">
            Trigger floating mode
        </button>
    </div>
</form>

<script src="https://cdn.jsdelivr.net/npm/@cap.js/widget"></script>
<script src="https://cdn.jsdelivr.net/npm/@cap.js/widget/cap-floating.min.js"></script> 
```