### PR TITLE
fix(server): skip signal handler registration when using custom storage

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -198,15 +198,17 @@ class Cap extends EventEmitter {
       this._loadTokens().catch(() => {});
     }
 
-    process.on("beforeExit", () => this.cleanup());
+    if (!this.config.noFSState && !this.config.storage?.tokens) {
+      process.on("beforeExit", () => this.cleanup());
 
-    ["SIGINT", "SIGTERM", "SIGQUIT"].forEach((signal) => {
-      process.once(signal, () => {
-        this.cleanup()
-          .then(() => process.exit(0))
-          .catch(() => process.exit(1));
+      ["SIGINT", "SIGTERM", "SIGQUIT"].forEach((signal) => {
+        process.once(signal, () => {
+          this.cleanup()
+            .then(() => process.exit(0))
+            .catch(() => process.exit(1));
+        });
       });
-    });
+    }
   }
 
   /**


### PR DESCRIPTION
## What

When `storage.tokens` is configured or `noFSState` is `true`, the signal handlers (`SIGINT`, `SIGTERM`, `SIGQUIT`, `beforeExit`) registered in the `Cap` constructor are unnecessary — `cleanup()` already skips the filesystem write in those cases (guarded by `!this.config.noFSState && !this.config.storage?.tokens?.store` at line 542).

## Why it matters

Unconditionally registering these handlers causes:
- `process.exit()` being called by the library, preventing the host app from performing its own graceful shutdown (closing DB connections, HTTP servers, etc.)
- Multiple `Cap` instances registering competing signal handlers
- The `beforeExit` handler never being removed (potential listener accumulation)

## Fix

Wrap the signal handler block in the same guard already used for `_loadTokens()` four lines above:

```js
if (!this.config.noFSState && !this.config.storage?.tokens) {
  process.on("beforeExit", () => this.cleanup());

  ["SIGINT", "SIGTERM", "SIGQUIT"].forEach((signal) => {
    process.once(signal, () => {
      this.cleanup()
        .then(() => process.exit(0))
        .catch(() => process.exit(1));
    });
  });
}
```

The condition mirrors `_loadTokens()` at line 197, and is semantically correct: these handlers exist solely to flush the token state to disk, so they're only needed when filesystem-based token storage is active.

Fixes #198