### PR TITLE
fix(widget): prevent shadow root re-attachment error in connectedCall…

### DIFF
--- a/widget/src/src/cap.js
+++ b/widget/src/src/cap.js
@@ -656,8 +656,14 @@
 
     async connectedCallback() {
       this.#host = this;
-      this.#shadow = this.attachShadow({ mode: "open" });
-      this.#div = document.createElement("div");
+
+      if (!this.shadowRoot) {
+        this.#shadow = this.attachShadow({ mode: "open" });
+      } else {
+        this.#shadow = this.shadowRoot;
+      }
+
+      if (!this.#div) this.#div = document.createElement("div");
       this.createUI();
       this.addEventListeners();
       this.initialize();


### PR DESCRIPTION
**## Description**
Fixes Issue #127. When the Cap widget is used inside a modal or any environment where it might be detached and re-attached to the DOM, `_connectedCallback()_` is triggered multiple times. 
Previously, it would attempt to call `_attachShadow()_` unconditionally, which throws a `_NotSupportedError_` if a shadow root already exists. This PR adds a check for `_this.shadowRoot_` to reuse the existing root if available, and ensures the internal `#div` is only created once.