### PR TITLE
fix(widget): guard async continuations against post-disconnect null access

### DIFF
--- a/widget/src/src/cap.js
+++ b/widget/src/src/cap.js
@@ -562,11 +562,13 @@
             this.#speculativePool
               .run(challenge[0], challenge[1])
               .then((nonce) => {
-                this.#speculative.completedCount++;
+                if (this.#speculative) this.#speculative.completedCount++;
                 return nonce;
               }),
           ),
         );
+
+        if (!this.#speculative) return;
 
         for (let i = 0; i < batchIndices.length; i++) {
           results[batchIndices[i]] = batchResults[i];
@@ -577,8 +579,11 @@
             setTimeout(resolve, SPECULATIVE_YIELD_MS),
           );
         }
+
+        if (!this.#speculative) return;
       }
 
+      if (!this.#speculative) return;
       this.#speculative.results = results;
       this.#speculative.state = "redeeming";
       this.#speculativeRedeem(results);
@@ -586,6 +591,7 @@
     }
 
     async #speculativeRedeem(solutions) {
+      if (!this.#speculative) return;
       try {
         const challengeResp = this.#speculative.challengeResp;
         const apiEndpoint = challengeResp._apiEndpoint;
@@ -597,6 +603,7 @@
           instrOut = await runInstrumentationChallenge(
             challengeResp.instrumentation,
           );
+          if (!this.#speculative) return;
           if (instrOut?.__timeout || instrOut?.__blocked) {
             this.#speculative.state = "done";
             this.#speculative.notify();
@@ -614,12 +621,16 @@
           headers: { "Content-Type": "application/json" },
         });
 
+        if (!this.#speculative) return;
+
         let resp;
         try {
           resp = await redeemRaw.json();
         } catch {
           throw new Error("Failed to parse speculative redeem response");
         }
+
+        if (!this.#speculative) return;
 
         if (!resp.success)
           throw new Error(resp.error || "Speculative redeem failed");
@@ -629,6 +640,7 @@
         this.#speculative.state = "done";
         this.#speculative.notify();
       } catch (e) {
+        if (!this.#speculative) return;
         console.warn(
           "[cap] speculative redeem failed (will redo on click):",
           e,
@@ -874,6 +886,7 @@
             }
 
             const progressInterval = setInterval(() => {
+              if (!this.#speculative) { clearInterval(progressInterval); return; }
               const st = this.#speculative.state;
               if (st === "done" || st === "error") {
                 clearInterval(progressInterval);
@@ -896,6 +909,7 @@
               this.#speculative.onSettled(resolve),
             );
             clearInterval(progressInterval);
+            if (!this.#speculative) return;
 
             if (
               this.#speculative.state === "idle" &&


### PR DESCRIPTION
## What this fixes

Closes #252.

When `<cap-widget>` is unmounted (or remounted via a React `key` change) while an async proof-of-work solve or speculative redeem is in flight, `disconnectedCallback` → `cleanup()` nullifies `this.#speculative` before those async continuations resume. Because the cleanup also calls `notify()` (which resolves any pending `onSettled` promises), the subsequent microtasks resume with `this.#speculative === null` and throw:

```
TypeError: can't access property "state", this.#speculative is null
```

## How I reproduced it

1. Loaded the widget in a React app.
2. Started a verification (triggering speculative solve).
3. Navigated away before verification completed — unmounting the element.
4. Observed the unhandled TypeError in the browser console.

## What I changed

Added `if (!this.#speculative) return;` guards at every async resumption point across three methods:

- **`#speculativeSolveAll`** — after `await Promise.all(...)` (the batch solve), after the speculative yield `setTimeout`, after the while loop, and inside the per-result `.then()` callback.
- **`#speculativeRedeem`** — at method entry, after the instrumentation `await`, after the `capFetch` await, after `.json()`, and at the top of the `catch` block.
- **`solve()`** — in the `setInterval` progress callback (clears the interval and returns early), and immediately after `await new Promise(resolve => this.#speculative.onSettled(resolve))`.

No new fields are introduced; the existing `cleanup()` already nullifies `#speculative`, which acts as the disconnection sentinel.

## Caveats / edge cases

- The `solve()` main path (non-speculative branch) doesn't access `#speculative` after its awaits, so it didn't need changes.
- The `finally { this.#solving = false; }` block in `solve()` still runs correctly on an early `return`.
- Existing unit tests (13/13) pass unchanged.

*— Claude, on behalf of Tiago*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mo2kqFdchfDXXsJsenvxJ6)_