### PR TITLE
fix(standalone): harden input validation on siteKey, siteverify body,…

### DIFF
--- a/standalone/src/cap.js
+++ b/standalone/src/cap.js
@@ -21,6 +21,8 @@ const DEFAULT_RSW_T = 75_000;
 const MIN_RSW_T = 10_000;
 const MAX_RSW_T = 300_000;
 
+const SITE_KEY_RE = /^[a-f0-9]{10}$/;
+
 function hourlyBucket() {
   return String(Math.floor(Date.now() / 1000 / 3600) * 3600);
 }
@@ -253,6 +255,12 @@ export const capServer = new Elysia({
       methods: ["POST"],
     }),
   )
+  .onBeforeHandle(({ params, set }) => {
+    if (params?.siteKey && !SITE_KEY_RE.test(params.siteKey)) {
+      set.status = 400;
+      return { error: "Invalid site key format" };
+    }
+  })
 
   .post(
     "/:siteKey/challenge",

--- a/standalone/src/server.js
+++ b/standalone/src/server.js
@@ -745,7 +745,8 @@ export const server = new Elysia({
       } else if (type === "country") {
         key = `country:${body.value}`;
       } else {
-        key = body.ip;
+        set.status = 400;
+        return { success: false, error: "Invalid block type" };
       }
 
       if (!key) {

--- a/standalone/src/siteverify.js
+++ b/standalone/src/siteverify.js
@@ -1,5 +1,5 @@
 import { cors } from "@elysiajs/cors";
-import { Elysia } from "elysia";
+import { Elysia, t } from "elysia";
 
 import { db } from "./db.js";
 import { checkCorsOrigin } from "./settings-cache.js";
@@ -15,54 +15,69 @@ export const siteverifyServer = new Elysia({
       methods: ["POST"],
     }),
   )
-  .post("/:siteKey?/siteverify", async ({ body, set, params }) => {
-    const sitekeyraw = params.siteKey || false;
-    const { secret, response } = body;
-    let sitekey = false;
-    if (response.split(":").length !== 3) {
-      set.status = 400;
-      return { success: false, error: "Missing required parameters" };
-    }
-    if (sitekeyraw) {
-      sitekey = sitekeyraw; //Overwrite if given as a parameter
-    } else {
-      sitekey = response.split(":")[0];
-    }
-    if (sitekeyraw && !response.startsWith(sitekeyraw)) {
-      set.status = 404;
-      return { success: false, error: "Invalid site key or secret" };
-    }
-    if (!secret || !response) {
-      set.status = 400;
-      return { success: false, error: "Missing required parameters" };
-    }
+  .post(
+    "/:siteKey?/siteverify",
+    async ({ body, set, params }) => {
+      const sitekeyraw = params.siteKey || false;
+      const { secret, response } = body;
+      let sitekey = false;
+      if (response.split(":").length !== 3) {
+        set.status = 400;
+        return { success: false, error: "Missing required parameters" };
+      }
+      if (sitekeyraw) {
+        sitekey = sitekeyraw; //Overwrite if given as a parameter
+      } else {
+        sitekey = response.split(":")[0];
+      }
+      if (sitekeyraw && !response.startsWith(sitekeyraw)) {
+        set.status = 404;
+        return { success: false, error: "Invalid site key or secret" };
+      }
+      if (!secret || !response) {
+        set.status = 400;
+        return { success: false, error: "Missing required parameters" };
+      }
 
-    const secretHash = await db.hget(`key:${sitekey}`, "secretHash");
+      const secretHash = await db.hget(`key:${sitekey}`, "secretHash");
 
-    if (!secretHash || !secret) {
-      set.status = 404;
-      return { success: false, error: "Invalid site key or secret" };
-    }
+      if (!secretHash || !secret) {
+        set.status = 404;
+        return { success: false, error: "Invalid site key or secret" };
+      }
 
-    const isValidSecret = await Bun.password.verify(secret, secretHash);
+      const isValidSecret = await Bun.password.verify(secret, secretHash);
 
-    if (!isValidSecret) {
-      set.status = 403;
-      return { success: false, error: "Invalid site key or secret" };
-    }
+      if (!isValidSecret) {
+        set.status = 403;
+        return { success: false, error: "Invalid site key or secret" };
+      }
 
-    const tokenKey = `token:${response}`;
-    const expires = await db.getdel(tokenKey);
+      const tokenKey = `token:${response}`;
+      const expires = await db.getdel(tokenKey);
 
-    if (!expires) {
-      set.status = 404;
-      return { success: false, error: "Token not found" };
-    }
+      if (!expires) {
+        set.status = 404;
+        return { success: false, error: "Token not found" };
+      }
 
-    if (Number(expires) < Date.now()) {
-      set.status = 403;
-      return { success: false, error: "Token expired" };
-    }
+      if (Number(expires) < Date.now()) {
+        set.status = 403;
+        return { success: false, error: "Token expired" };
+      }
 
-    return { success: true };
-  });
+      return { success: true };
+    },
+    {
+      body: t.Object({
+        secret: t.String(),
+        response: t.String(),
+      }),
+      params: t.Object({
+        siteKey: t.Optional(t.String()),
+      }),
+      detail: {
+        tags: ["Challenges"],
+      },
+    },
+  );

--- a/standalone/src/siteverify.js
+++ b/standalone/src/siteverify.js
@@ -69,10 +69,13 @@ export const siteverifyServer = new Elysia({
       return { success: true };
     },
     {
-      body: t.Object({
-        secret: t.Optional(t.String()),
-        response: t.Optional(t.String()),
-      }),
+      body: t.Object(
+        {
+          secret: t.Optional(t.String()),
+          response: t.Optional(t.String()),
+        },
+        { additionalProperties: true },
+      ),
       params: t.Object({
         siteKey: t.Optional(t.String()),
       }),

--- a/standalone/src/siteverify.js
+++ b/standalone/src/siteverify.js
@@ -21,7 +21,7 @@ export const siteverifyServer = new Elysia({
       const sitekeyraw = params.siteKey || false;
       const { secret, response } = body;
       let sitekey = false;
-      if (response.split(":").length !== 3) {
+      if (!response || response.split(":").length !== 3) {
         set.status = 400;
         return { success: false, error: "Missing required parameters" };
       }
@@ -70,8 +70,8 @@ export const siteverifyServer = new Elysia({
     },
     {
       body: t.Object({
-        secret: t.String(),
-        response: t.String(),
+        secret: t.Optional(t.String()),
+        response: t.Optional(t.String()),
       }),
       params: t.Object({
         siteKey: t.Optional(t.String()),

--- a/standalone/test/cap-routes.test.js
+++ b/standalone/test/cap-routes.test.js
@@ -27,7 +27,7 @@ if (!redisAvailable) {
   const { capServer } = await import("../src/cap.js");
   const { db } = await import("../src/db.js");
   const { generateChallenge: cgChallenge } = await import("capjs-core");
-  const { createHash } = await import("node:crypto");
+  const { createHash, randomBytes } = await import("node:crypto");
 
   function fnv1a(str) {
     let hash = 2166136261;
@@ -55,7 +55,7 @@ if (!redisAvailable) {
   }
 
   const app = new Elysia().use(capServer);
-  const SITE_KEY = `test_site_key_${Math.random().toString(16).slice(2)}`;
+  const SITE_KEY = randomBytes(5).toString("hex");
   const SECRET = "test-jwt-secret-32-bytes-padding-junk-1!";
 
   beforeAll(async () => {
@@ -211,7 +211,7 @@ if (!redisAvailable) {
     test("RSW: issues format-2 challenge and accepts solution", async () => {
       const { ensureRswKeypair } = await import("../src/rsw-store.js");
       await ensureRswKeypair();
-      const rswKey = `rsw_site_key_${Math.random().toString(16).slice(2)}`;
+      const rswKey = randomBytes(5).toString("hex");
       const rswT = 10_000;
       await db.send("HSET", [
         `key:${rswKey}`,
@@ -260,7 +260,7 @@ if (!redisAvailable) {
     }, 30_000);
 
     test("rejects scope mismatch (token from another site key)", async () => {
-      const otherKey = `other_site_key_${Math.random().toString(16).slice(2)}`;
+      const otherKey = randomBytes(5).toString("hex");
       await db.send("HSET", [
         `key:${otherKey}`,
         "config",

--- a/standalone/test/cap-routes.test.js
+++ b/standalone/test/cap-routes.test.js
@@ -122,7 +122,7 @@ if (!redisAvailable) {
 
     test("returns 404 for unknown site key", async () => {
       const res = await app.handle(
-        new Request("http://localhost/nonexistent_key/challenge", {
+        new Request("http://localhost/0000000000/challenge", {
           method: "POST",
         }),
       );


### PR DESCRIPTION
## Description

This PR introduces three focused input validation and defense-in-depth improvements to the standalone server to harden its security posture.

### 1. Added schema validation to `/siteverify`
The `siteverify.js` endpoint was the only route missing Elysia's `t.Object` body schema validation. Because it relied on raw destructuring (`const { secret, response } = body;`), passing non-string payloads (e.g., arrays or objects) would cause unhandled `TypeError` exceptions (e.g., `response.split is not a function`), potentially leading to unexpected crashes. 
- **Fix:** Added standard Elysia `t.Object` body and params validation to guarantee correct types before the handler executes.

### 2. Guarded `siteKey` path params against format manipulation
The `siteKey` path parameter is used extensively in direct Redis key construction (e.g., `key:${siteKey}`). Previously, any arbitrary string was accepted as a `siteKey` parameter.
- **Fix:** Added a regex constraint (`/^[a-f0-9]{10}$/`) via `onBeforeHandle` to ensure that only properly formatted 10-character hex keys (matching the `randomBytes(5)` generation logic) can hit the database. This eliminates any risk of key namespace pollution or Redis protocol injection.

### 3. Fixed fallthrough bug in `unblock-ip`
In `server.js`, the `block-ip` handler correctly returns a `400` error if an unknown `type` is passed. However, the `unblock-ip` handler silently fell through and treated unknown types as an `ip` (`key = body.ip;`). 
- **Fix:** Aligned `unblock-ip` with `block-ip` to return a `400 Bad Request` for invalid block types, preventing accidental unblocking of the wrong entries.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security improvement

## Checklist
- [x] I have tested these changes locally
- [x] I have run `biome check` and fixed all warnings/errors
