### PR TITLE
Add configurable challenge expiration

### DIFF
--- a/docs/guide/standalone/options.md
+++ b/docs/guide/standalone/options.md
@@ -45,6 +45,12 @@ If so, you can change the IP extraction logic to simply read from a header set i
 
 The `/siteverify` endpoint is intended for server-to-server use, so it's not ratelimited by default.
 
+## Challenge expiration
+
+Generated challenges expire after 15 minutes by default. You can change the global default with `CHALLENGE_TTL_MS`, or set **Challenge expiration (ms)** on an individual key in the dashboard. Per-key values take priority over `CHALLENGE_TTL_MS`.
+
+The widget also treats the challenge's existing `expires` value as a client-side deadline. If a slow device or high-difficulty challenge runs past that deadline, the widget aborts its workers and shows an error instead of spinning indefinitely.
+
 ## Redis / Valkey
 
 Cap Standalone uses Redis (or Valkey) for all data storage. Set the `REDIS_URL` environment variable to your Redis connection string. This defaults to `redis://localhost:6379`.

--- a/standalone/public/js/dashboard.js
+++ b/standalone/public/js/dashboard.js
@@ -574,6 +574,10 @@ function renderKeyDetail() {
               <input type="range" id="cfgRswT" min="10000" max="300000" step="5000" value="${key.config.rswT ?? 75000}">
             </div>
           </div>
+          <div class="edit-field" style="margin-top:8px">
+            <label>Challenge expiration (ms)</label>
+            <input type="number" id="cfgExpiresMs" value="${key.config.expiresMs ?? ""}" min="1000" max="86400000" step="1000" placeholder="900000">
+          </div>
           <h3 class="config-section-title" style="margin-top:16px">Instrumentation</h3>
           <div class="switch-field">
             <label class="switch">
@@ -803,6 +807,8 @@ function renderKeyDetail() {
     const blockAutomatedBrowsers = document.getElementById("cfgBlockAutomatedBrowsers").checked;
     const rsw = document.getElementById("cfgChallengeProtocol").value === "rsw";
     const rswT = parseInt(document.getElementById("cfgRswT").value, 10);
+    const expiresVal = document.getElementById("cfgExpiresMs").value;
+    const expiresMs = expiresVal === "" ? null : parseInt(expiresVal, 10);
     const dirty =
       name !== key.name ||
       difficulty !== key.config.difficulty ||
@@ -811,7 +817,8 @@ function renderKeyDetail() {
       obfuscationLevel !== (key.config.obfuscationLevel ?? 5) ||
       blockAutomatedBrowsers !== key.config.blockAutomatedBrowsers ||
       rsw !== !!key.config.rsw ||
-      rswT !== (key.config.rswT ?? 75000);
+      rswT !== (key.config.rswT ?? 75000) ||
+      expiresMs !== (key.config.expiresMs ?? null);
     document.getElementById("saveMainConfigBtn").disabled = !dirty;
   }
 
@@ -841,7 +848,7 @@ function renderKeyDetail() {
     checkSecurityDirty();
   }
 
-  for (const id of ["cfgName", "cfgDifficulty", "cfgChallengeCount"]) {
+  for (const id of ["cfgName", "cfgDifficulty", "cfgChallengeCount", "cfgExpiresMs"]) {
     document.getElementById(id)?.addEventListener("input", checkMainDirty);
   }
   for (const id of ["cfgRatelimitMax", "cfgRatelimitDuration"]) {
@@ -2345,8 +2352,15 @@ async function saveMainConfig() {
   const blockAutomatedBrowsers = document.getElementById("cfgBlockAutomatedBrowsers").checked;
   const rsw = document.getElementById("cfgChallengeProtocol").value === "rsw";
   const rswT = parseInt(document.getElementById("cfgRswT").value, 10);
+  const expiresVal = document.getElementById("cfgExpiresMs").value;
+  const expiresMs = expiresVal === "" ? null : parseInt(expiresVal, 10);
 
-  if (!name || difficulty < 1 || challengeCount < 1) {
+  if (
+    !name ||
+    difficulty < 1 ||
+    challengeCount < 1 ||
+    (expiresMs !== null && (expiresMs < 1000 || expiresMs > 86400000))
+  ) {
     showModal(
       "Validation error",
       '<div class="modal-body"><p>Please check your input values.</p></div>',
@@ -2379,6 +2393,7 @@ async function saveMainConfig() {
     blockAutomatedBrowsers,
     rsw,
     rswT,
+    expiresMs,
   });
 
   if (res.success) {
@@ -2393,6 +2408,7 @@ async function saveMainConfig() {
       blockAutomatedBrowsers,
       rsw,
       rswT,
+      expiresMs,
     };
     renderKeysList(searchInput.value);
   } else {

--- a/standalone/src/cap.js
+++ b/standalone/src/cap.js
@@ -69,8 +69,22 @@ function getClientIp(request, srv) {
   return srv?.requestIP(request)?.address || null;
 }
 
-const CHALLENGE_TTL_MS = 15 * 60 * 1000; // 15min
+const DEFAULT_CHALLENGE_TTL_MS = 15 * 60 * 1000; // 15min
 const TOKEN_TTL_MS = 2 * 60 * 60 * 1000; // 2h
+
+function parseTtlMs(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const CHALLENGE_TTL_MS = parseTtlMs(
+  process.env.CHALLENGE_TTL_MS,
+  DEFAULT_CHALLENGE_TTL_MS,
+);
+
+function resolveChallengeTtlMs(keyConfig) {
+  return parseTtlMs(keyConfig?.expiresMs, CHALLENGE_TTL_MS);
+}
 
 function ipv4ToInt(a) {
   return a.split(".").reduce((r, b) => (r << 8) + parseInt(b, 10), 0) >>> 0;
@@ -372,6 +386,7 @@ export const capServer = new Elysia({
             obfuscationLevel: keyConfig.obfuscationLevel,
           }
         : false;
+      const challengeTtlMs = resolveChallengeTtlMs(keyConfig);
 
       let challengeOpts;
       if (keyConfig.rsw) {
@@ -399,7 +414,7 @@ export const capServer = new Elysia({
             : ["rsw"],
           keypair,
           t,
-          expiresMs: CHALLENGE_TTL_MS,
+          expiresMs: challengeTtlMs,
           scope: params.siteKey,
           instrumentation: instrumentationOpts,
         };
@@ -408,7 +423,7 @@ export const capServer = new Elysia({
           challengeCount: keyConfig.challengeCount ?? 80,
           challengeSize: keyConfig.saltSize ?? 32,
           challengeDifficulty: keyConfig.difficulty ?? 4,
-          expiresMs: CHALLENGE_TTL_MS,
+          expiresMs: challengeTtlMs,
           scope: params.siteKey,
           instrumentation: instrumentationOpts,
         };

--- a/standalone/src/server.js
+++ b/standalone/src/server.js
@@ -34,6 +34,7 @@ const keyDefaults = {
   blockAutomatedBrowsers: false,
   rsw: false,
   rswT: 75_000,
+  expiresMs: null,
 };
 
 const sumSolutions = (data, startBucket, endBucket) => {
@@ -154,6 +155,7 @@ export const server = new Elysia({
         blockAutomatedBrowsers: body?.blockAutomatedBrowsers ?? false,
         rsw: body?.rsw ?? false,
         rswT: body?.rswT ?? keyDefaults.rswT,
+        expiresMs: body?.expiresMs ?? keyDefaults.expiresMs,
       };
 
       if (
@@ -191,6 +193,9 @@ export const server = new Elysia({
         corsOrigins: t.Optional(t.Array(t.String())),
         rsw: t.Optional(t.Boolean()),
         rswT: t.Optional(t.Number({ minimum: 10000, maximum: 300000 })),
+        expiresMs: t.Optional(
+          t.Union([t.Number({ minimum: 1000, maximum: 86400000 }), t.Null()]),
+        ),
       }),
       detail: {
         tags: ["Keys"],
@@ -453,6 +458,7 @@ export const server = new Elysia({
         blockAutomatedBrowsers,
         ratelimitMax,
         ratelimitDuration,
+        expiresMs,
         corsOrigins,
         blockNonBrowserUA,
         requiredHeaders,
@@ -483,6 +489,8 @@ export const server = new Elysia({
           ratelimitDuration !== undefined
             ? ratelimitDuration
             : (existingConfig.ratelimitDuration ?? null),
+        expiresMs:
+          expiresMs !== undefined ? expiresMs : (existingConfig.expiresMs ?? null),
         corsOrigins:
           corsOrigins !== undefined
             ? corsOrigins
@@ -525,6 +533,9 @@ export const server = new Elysia({
         ),
         ratelimitDuration: t.Optional(
           t.Union([t.Number({ minimum: 1000, maximum: 3600000 }), t.Null()]),
+        ),
+        expiresMs: t.Optional(
+          t.Union([t.Number({ minimum: 1000, maximum: 86400000 }), t.Null()]),
         ),
         corsOrigins: t.Optional(t.Union([t.Array(t.String()), t.Null()])),
         blockNonBrowserUA: t.Optional(t.Union([t.Boolean(), t.Null()])),

--- a/standalone/test/cap-routes.test.js
+++ b/standalone/test/cap-routes.test.js
@@ -120,6 +120,39 @@ if (!redisAvailable) {
       expect(body.expires).toBeGreaterThan(Date.now());
     });
 
+    test("uses per-key expiresMs for challenge TTL", async () => {
+      const ttlKey = `ttl_site_key_${Math.random().toString(16).slice(2)}`;
+      const expiresMs = 2_000;
+      await db.send("HSET", [
+        `key:${ttlKey}`,
+        "config",
+        JSON.stringify({
+          challengeCount: 1,
+          saltSize: 4,
+          difficulty: 1,
+          instrumentation: false,
+          expiresMs,
+        }),
+        "jwtSecret",
+        SECRET,
+      ]);
+      try {
+        const before = Date.now();
+        const res = await app.handle(
+          new Request(`http://localhost/${ttlKey}/challenge`, {
+            method: "POST",
+          }),
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        const after = Date.now();
+        expect(body.expires).toBeGreaterThanOrEqual(before + expiresMs);
+        expect(body.expires).toBeLessThanOrEqual(after + expiresMs + 100);
+      } finally {
+        await db.send("DEL", [`key:${ttlKey}`]);
+      }
+    });
+
     test("returns 404 for unknown site key", async () => {
       const res = await app.handle(
         new Request("http://localhost/nonexistent_key/challenge", {

--- a/widget/src/src/cap.js
+++ b/widget/src/src/cap.js
@@ -206,6 +206,44 @@
   const SPECULATIVE_WORKERS = 1;
   const SPECULATIVE_YIELD_MS = 120;
 
+  function getChallengeDeadlineMs(challengeResp) {
+    const expires = challengeResp?.expires;
+    if (expires === undefined || expires === null) return null;
+
+    const deadline =
+      typeof expires === "number" ? expires : new Date(expires).getTime();
+    return Number.isFinite(deadline) ? deadline : null;
+  }
+
+  function getChallengeTimeRemaining(deadlineMs) {
+    if (deadlineMs === null || deadlineMs === undefined) return Infinity;
+    return deadlineMs - Date.now();
+  }
+
+  async function withChallengeDeadline(work, deadlineMs, onExpire) {
+    const remainingMs = getChallengeTimeRemaining(deadlineMs);
+    if (remainingMs <= 0) {
+      onExpire?.();
+      throw new Error("Challenge expired");
+    }
+    if (!Number.isFinite(remainingMs)) return await work();
+
+    let timer = null;
+    try {
+      return await Promise.race([
+        work(),
+        new Promise((_, reject) => {
+          timer = setTimeout(() => {
+            onExpire?.();
+            reject(new Error("Challenge expired"));
+          }, remainingMs);
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
   let _sharedWorkerUrl = null;
 
   function _getSharedWorkerUrl() {
@@ -381,6 +419,7 @@
         state: "idle",
         challengeResp: null,
         challenges: null,
+        deadlineMs: null,
         results: [],
         completedCount: 0,
         solvePromise: null,
@@ -478,7 +517,12 @@
         if (resp.error) throw new Error(resp.error);
 
         resp._apiEndpoint = apiEndpoint;
+        const deadlineMs = getChallengeDeadlineMs(resp);
+        if (getChallengeTimeRemaining(deadlineMs) <= 0) {
+          throw new Error("Challenge expired");
+        }
         this.#speculative.challengeResp = resp;
+        this.#speculative.deadlineMs = deadlineMs;
 
         if (resp.format === 2 && Array.isArray(resp.challenges)) {
           this.#speculative.state = "idle";
@@ -501,7 +545,10 @@
         this.#speculative.challenges = challenges;
         this.#speculative.state = "solving";
 
-        this.#speculative.solvePromise = this.#speculativeSolveAll(challenges);
+        this.#speculative.solvePromise = this.#speculativeSolveAll(
+          challenges,
+          deadlineMs,
+        ).catch(() => {});
       } catch (e) {
         console.warn("[cap] speculative challenge fetch failed:", e);
         this.#speculative.state = "error";
@@ -509,7 +556,7 @@
       }
     }
 
-    async #speculativeSolveAll(challenges) {
+    async #speculativeSolveAll(challenges, deadlineMs) {
       _getSharedWorkerUrl();
 
       let wasmModule = null;
@@ -544,49 +591,67 @@
 
       let nextIndex = 0;
 
-      while (nextIndex < total) {
-        const batchSize = concurrency;
-        const batch = [];
-        const batchIndices = [];
+      try {
+        await withChallengeDeadline(
+          async () => {
+            while (nextIndex < total) {
+              const batchSize = concurrency;
+              const batch = [];
+              const batchIndices = [];
 
-        for (let i = 0; i < batchSize && nextIndex < total; i++) {
-          batchIndices.push(nextIndex);
-          batch.push(challenges[nextIndex]);
-          nextIndex++;
-        }
+              for (let i = 0; i < batchSize && nextIndex < total; i++) {
+                batchIndices.push(nextIndex);
+                batch.push(challenges[nextIndex]);
+                nextIndex++;
+              }
 
-        this.#speculativePool._ensureSize(Math.max(concurrency, batchSize));
+              this.#speculativePool._ensureSize(
+                Math.max(concurrency, batchSize),
+              );
 
-        const batchResults = await Promise.all(
-          batch.map((challenge) =>
-            this.#speculativePool
-              .run(challenge[0], challenge[1])
-              .then((nonce) => {
-                this.#speculative.completedCount++;
-                return nonce;
-              }),
-          ),
+              const batchResults = await Promise.all(
+                batch.map((challenge) =>
+                  this.#speculativePool
+                    .run(challenge[0], challenge[1])
+                    .then((nonce) => {
+                      this.#speculative.completedCount++;
+                      return nonce;
+                    }),
+                ),
+              );
+
+              for (let i = 0; i < batchIndices.length; i++) {
+                results[batchIndices[i]] = batchResults[i];
+              }
+
+              if (!promoted && nextIndex < total) {
+                await new Promise((resolve) =>
+                  setTimeout(resolve, SPECULATIVE_YIELD_MS),
+                );
+              }
+            }
+          },
+          deadlineMs,
+          () => this.#speculativePool?.terminate(),
         );
-
-        for (let i = 0; i < batchIndices.length; i++) {
-          results[batchIndices[i]] = batchResults[i];
-        }
-
-        if (!promoted && nextIndex < total) {
-          await new Promise((resolve) =>
-            setTimeout(resolve, SPECULATIVE_YIELD_MS),
-          );
-        }
+      } catch (e) {
+        this.#speculative.state = "error";
+        this.#speculative.notify();
+        throw e;
       }
 
       this.#speculative.results = results;
       this.#speculative.state = "redeeming";
-      this.#speculativeRedeem(results);
+      this.#speculativeRedeem(results, deadlineMs);
       return results;
     }
 
-    async #speculativeRedeem(solutions) {
+    async #speculativeRedeem(solutions, deadlineMs) {
       try {
+        if (getChallengeTimeRemaining(deadlineMs) <= 0) {
+          throw new Error("Challenge expired");
+        }
+
         const challengeResp = this.#speculative.challengeResp;
         const apiEndpoint = challengeResp._apiEndpoint;
         if (!apiEndpoint)
@@ -633,7 +698,8 @@
           "[cap] speculative redeem failed (will redo on click):",
           e,
         );
-        this.#speculative.state = "done";
+        this.#speculative.state =
+          e?.message === "Challenge expired" ? "error" : "done";
         this.#speculative.notify();
       }
     }
@@ -813,6 +879,7 @@
 
           let solutions;
           let challengeResp;
+          let deadlineMs;
 
           if (
             this.#speculative.state === "done" &&
@@ -852,6 +919,7 @@
           if (this.#speculative.state === "done") {
             solutions = this.#speculative.results;
             challengeResp = this.#speculative.challengeResp;
+            deadlineMs = this.#speculative.deadlineMs;
             this.dispatchEvent("progress", { progress: 100 });
           } else if (
             this.#speculative.state === "solving" ||
@@ -904,7 +972,11 @@
             ) {
               challengeResp = this.#speculative.challengeResp;
               this.#speculative.challengeResp = null;
-              solutions = await this.solveChallengesV2(challengeResp.challenges);
+              deadlineMs = getChallengeDeadlineMs(challengeResp);
+              solutions = await this.solveChallengesV2(
+                challengeResp.challenges,
+                deadlineMs,
+              );
             } else {
               if (this.#speculative.state !== "done") {
                 throw new Error("Speculative solve failed – please try again");
@@ -946,6 +1018,7 @@
 
             solutions = this.#speculative.results;
             challengeResp = this.#speculative.challengeResp;
+            deadlineMs = this.#speculative.deadlineMs;
             this.dispatchEvent("progress", { progress: 100 });
             }
           } else {
@@ -969,8 +1042,13 @@
               challengeResp.format === 2 &&
               Array.isArray(challengeResp.challenges)
             ) {
-              solutions = await this.solveChallengesV2(challengeResp.challenges);
+              deadlineMs = getChallengeDeadlineMs(challengeResp);
+              solutions = await this.solveChallengesV2(
+                challengeResp.challenges,
+                deadlineMs,
+              );
             } else {
+              deadlineMs = getChallengeDeadlineMs(challengeResp);
               const { challenge, token } = challengeResp;
               let challenges = challenge;
               if (!Array.isArray(challenges)) {
@@ -983,15 +1061,24 @@
                   ];
                 });
               }
-              solutions = await this.solveChallenges(challenges);
+              solutions = await this.solveChallenges(challenges, deadlineMs);
             }
           }
 
-          const instrPromise = challengeResp.instrumentation
-            ? runInstrumentationChallenge(challengeResp.instrumentation)
-            : Promise.resolve(null);
+          if (deadlineMs === undefined) {
+            deadlineMs = getChallengeDeadlineMs(challengeResp);
+          }
+          if (getChallengeTimeRemaining(deadlineMs) <= 0) {
+            throw new Error("Challenge expired");
+          }
 
-          const instrOut = await instrPromise;
+          const instrOut = await withChallengeDeadline(
+            () =>
+              challengeResp.instrumentation
+                ? runInstrumentationChallenge(challengeResp.instrumentation)
+                : Promise.resolve(null),
+            deadlineMs,
+          );
 
           if (instrOut?.__timeout || instrOut?.__blocked) {
             capFetch(`${apiEndpoint}redeem`, {
@@ -1031,6 +1118,9 @@
           }
 
           const { token } = challengeResp;
+          if (getChallengeTimeRemaining(deadlineMs) <= 0) {
+            throw new Error("Challenge expired");
+          }
 
           const redeemResponse = await capFetch(`${apiEndpoint}redeem`, {
             method: "POST",
@@ -1097,7 +1187,7 @@
       }
     }
 
-    async solveChallengesV2(challenges) {
+    async solveChallengesV2(challenges, deadlineMs = null) {
       const total = challenges.length;
       let completed = 0;
 
@@ -1150,44 +1240,49 @@
       };
 
       try {
-        await Promise.all(
-          challenges.map((ch, idx) => {
-            if (ch.protocol === "sha256-pow") {
-              return withTimeout(
-                pool.run(ch.payload.salt, ch.payload.target),
-                `sha256-pow worker #${idx}`,
-              ).then((nonce) => {
-                solutions[idx] = { nonce: Number(nonce) };
-                inFlight[idx] = 0;
-                completed++;
-                emit();
-              });
-            }
+        await withChallengeDeadline(
+          async () =>
+            await Promise.all(
+              challenges.map((ch, idx) => {
+                if (ch.protocol === "sha256-pow") {
+                  return withTimeout(
+                    pool.run(ch.payload.salt, ch.payload.target),
+                    `sha256-pow worker #${idx}`,
+                  ).then((nonce) => {
+                    solutions[idx] = { nonce: Number(nonce) };
+                    inFlight[idx] = 0;
+                    completed++;
+                    emit();
+                  });
+                }
 
-            if (ch.protocol === "rsw") {
-              return withTimeout(
-                pool.runMsg(
-                  { kind: "rsw", N: ch.payload.N, x: ch.payload.x, t: ch.payload.t | 0 },
-                  (p) => { inFlight[idx] = p; emit(); },
-                ),
-                `rsw worker #${idx}`,
-              ).then((data) => {
-                solutions[idx] = { y: data.y };
-                inFlight[idx] = 0;
-                completed++;
-                emit();
-              });
-            }
-            
-            return runInstrumentationChallenge(ch.payload.blob).then((out) => {
-              if (out?.__timeout) solutions[idx] = { timeout: true };
-              else if (out?.__blocked) solutions[idx] = { blocked: true };
-              else solutions[idx] = { instr: out };
-              inFlight[idx] = 0;
-              completed++;
-              emit();
-            });
-          }),
+                if (ch.protocol === "rsw") {
+                  return withTimeout(
+                    pool.runMsg(
+                      { kind: "rsw", N: ch.payload.N, x: ch.payload.x, t: ch.payload.t | 0 },
+                      (p) => { inFlight[idx] = p; emit(); },
+                    ),
+                    `rsw worker #${idx}`,
+                  ).then((data) => {
+                    solutions[idx] = { y: data.y };
+                    inFlight[idx] = 0;
+                    completed++;
+                    emit();
+                  });
+                }
+
+                return runInstrumentationChallenge(ch.payload.blob).then((out) => {
+                  if (out?.__timeout) solutions[idx] = { timeout: true };
+                  else if (out?.__blocked) solutions[idx] = { blocked: true };
+                  else solutions[idx] = { instr: out };
+                  inFlight[idx] = 0;
+                  completed++;
+                  emit();
+                });
+              }),
+            ),
+          deadlineMs,
+          () => pool.terminate(),
         );
       } finally {
         pool.terminate();
@@ -1196,7 +1291,7 @@
       return solutions;
     }
 
-    async solveChallenges(challenges) {
+    async solveChallenges(challenges, deadlineMs = null) {
       const total = challenges.length;
       let completed = 0;
 
@@ -1238,26 +1333,32 @@
 
       const results = [];
       try {
-        for (let i = 0; i < challenges.length; i += this.#workersCount) {
-          const chunk = challenges.slice(
-            i,
-            Math.min(i + this.#workersCount, challenges.length),
-          );
-          const chunkResults = await Promise.all(
-            chunk.map(([salt, target]) =>
-              pool.run(salt, target).then((nonce) => {
-                completed++;
-                const visual = Math.min(
-                  99,
-                  Math.round(((speculativeHead + completed) / total) * 100),
-                );
-                this.dispatchEvent("progress", { progress: visual });
-                return nonce;
-              }),
-            ),
-          );
-          results.push(...chunkResults);
-        }
+        await withChallengeDeadline(
+          async () => {
+            for (let i = 0; i < challenges.length; i += this.#workersCount) {
+              const chunk = challenges.slice(
+                i,
+                Math.min(i + this.#workersCount, challenges.length),
+              );
+              const chunkResults = await Promise.all(
+                chunk.map(([salt, target]) =>
+                  pool.run(salt, target).then((nonce) => {
+                    completed++;
+                    const visual = Math.min(
+                      99,
+                      Math.round(((speculativeHead + completed) / total) * 100),
+                    );
+                    this.dispatchEvent("progress", { progress: visual });
+                    return nonce;
+                  }),
+                ),
+              );
+              results.push(...chunkResults);
+            }
+          },
+          deadlineMs,
+          () => pool.terminate(),
+        );
       } finally {
         pool.terminate();
       }

--- a/widget/test/unit.test.js
+++ b/widget/test/unit.test.js
@@ -30,6 +30,15 @@ describe("widget source structure", () => {
     expect(widgetSource).toMatch(/SPECULATIVE_DELAY_MS = 2500/);
   });
 
+  test("uses challenge expires as the worker deadline", () => {
+    expect(widgetSource).toContain("function getChallengeDeadlineMs");
+    expect(widgetSource).toContain("function withChallengeDeadline");
+    expect(widgetSource).toMatch(/solveChallenges\(challenges, deadlineMs = null\)/);
+    expect(widgetSource).toMatch(/solveChallengesV2\(challenges, deadlineMs = null\)/);
+    expect(widgetSource).toMatch(/onExpire\?\.\(\)/);
+    expect(widgetSource).toMatch(/pool\.terminate\(\)/);
+  });
+
   test("includes %%workerScript%% placeholder for build step", () => {
     expect(widgetSource).toContain("%%workerScript%%");
   });


### PR DESCRIPTION
Summary:
- add per-key and env-level challenge TTL configuration
- expose challenge expiration in the standalone dashboard
- make the widget stop solving and fail clearly when a challenge expires
- add route and widget regression coverage for expiration behavior

Verification:
- node --check standalone/src/cap.js
- node --check standalone/src/server.js
- node --check standalone/public/js/dashboard.js
- widget source parsed with worker placeholder substitution
- git diff --check
- bun tests not run because bun is not installed in this environment

Fixes #209

No payment expected upfront. If this PR is useful and gets merged, an optional tip/donation is appreciated so I can keep doing small maintainer-unblocking fixes.