### PR TITLE
feat(docs): add cap-captcha-keycloak to community guide

### DIFF
--- a/docs/guide/community.md
+++ b/docs/guide/community.md
@@ -53,6 +53,8 @@ These are React hook implementations of the Cap API, allowing full customization
 
 - **[wuhunyu/cap-server-java](https://github.com/wuhunyu/cap-server-java)**
 
+- **[schwebke/cap-captcha-keycloak](https://github.com/schwebke/cap-captcha-keycloak)**: Keycloak extension providing Cap captcha validation for the registration flow
+
 ### Go
 
 - **[samwafgo/cap_go_server](https://github.com/samwafgo/cap_go_server)**


### PR DESCRIPTION
## What
Adds [cap-captcha-keycloak](https://github.com/schwebke/cap-captcha-keycloak) to the **Server → Java** section of `docs/guide/community.md`.

A Keycloak extension providing Cap captcha validation for the registration flow — server-side Java integration that verifies Cap tokens via the reCAPTCHA-compatible `siteverify` endpoint, fail-closed.

## Why
Mirrors how `cap-captcha-wordpress` (a plugin, not a pure server lib) is listed under **Server → PHP**. A Keycloak SPI is the Java equivalent: a server-side framework integration rather than a standalone server. Placed after `wuhunyu/cap-server-java`, keeping the section's existing blank-line-between-entries style.
