### PR TITLE
feat(docs): add showcase page for organizations using Cap

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -356,6 +356,7 @@ export default withMermaid({
         { text: "Benchmark", link: "/guide/benchmark.md" },
         { text: "Compliance", link: "/guide/compliance.md" },
         { text: "Demo", link: "/guide/demo.md" },
+        { text: "Who's Using Cap", link: "/guide/showcase.md" },
         { text: "GitHub", link: "https://github.com/tiagozip/cap" },
       ],
     },

--- a/docs/.vitepress/theme/components/HomeV2.vue
+++ b/docs/.vitepress/theme/components/HomeV2.vue
@@ -648,6 +648,13 @@ onBeforeUnmount(() => {
                 loading="lazy"
               />
             </span>
+            <a
+              class="logoimg-more"
+              href="/guide/showcase.html"
+              data-cta="users"
+              data-cta-location="home_trust"
+              >See all <span class="arr">→</span></a
+            >
           </div>
         </div>
       </div>
@@ -2163,6 +2170,25 @@ html.home-v2-active main.main {
 }
 #homev2 img.li:hover {
   opacity: 1;
+}
+#homev2 .logoimg-more {
+  font-family: var(--mono);
+  font-weight: 400;
+  font-size: 11px;
+  color: var(--fg-mute);
+  text-decoration: none;
+  transition: color 0.18s ease;
+}
+#homev2 .logoimg-more:hover {
+  color: var(--fg);
+  text-decoration: underline;
+}
+#homev2 .logoimg-more .arr {
+  display: inline-block;
+  transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+}
+#homev2 .logoimg-more:hover .arr {
+  transform: translateX(3px);
 }
 
 #homev2 .how-grid {

--- a/docs/.vitepress/theme/data/showcase.ts
+++ b/docs/.vitepress/theme/data/showcase.ts
@@ -1,0 +1,25 @@
+export interface ShowcaseEntry {
+  name: string
+  logo: string
+  url: string
+}
+
+const showcase: ShowcaseEntry[] = [
+  {
+    name: 'bunny.net',
+    logo: '/logos/bunny.svg',
+    url: 'https://bunny.net',
+  },
+  {
+    name: 'AdGuard',
+    logo: '/logos/adguard.svg',
+    url: 'https://adguard.com',
+  },
+  {
+    name: 'Fraunhofer',
+    logo: '/logos/fraunhofer.svg',
+    url: 'https://www.fraunhofer.de',
+  },
+]
+
+export default showcase

--- a/docs/guide/showcase.md
+++ b/docs/guide/showcase.md
@@ -1,0 +1,95 @@
+<script setup>
+import showcase from '../.vitepress/theme/data/showcase'
+</script>
+
+# Who's Using Cap
+
+Organizations and projects that trust Cap for their CAPTCHA needs.
+
+<div class="users-grid">
+
+<div v-for="entry in showcase" :key="entry.name" class="user-card">
+  <a :href="entry.url" target="_blank" rel="noopener noreferrer" class="user-logo-wrap">
+    <img
+      :src="entry.logo"
+      :alt="entry.name"
+      class="user-logo"
+      loading="lazy"
+    />
+  </a>
+  <a :href="entry.url" target="_blank" rel="noopener noreferrer" class="user-name">{{ entry.name }}</a>
+</div>
+
+</div>
+
+---
+
+## Add Your Organization
+
+Using Cap in production? We'd love to feature your logo here.
+
+1. Add your logo as an SVG file to [`docs/public/logos/`](https://github.com/tiagozip/cap/tree/main/docs/public/logos) following the [logo guidelines](https://github.com/tiagozip/cap/blob/main/docs/public/logos/README.md)
+   - Use a **horizontal/landscape** logo when possible
+   - Keep the viewBox proportional — the logo will be displayed at a consistent height
+   - Optimize the SVG (remove unnecessary metadata, minify paths)
+2. Add your entry to [`docs/.vitepress/theme/data/showcase.ts`](https://github.com/tiagozip/cap/blob/main/docs/.vitepress/theme/data/showcase.ts)
+3. Open a pull request
+
+We'll review and merge it. Thank you for supporting Cap!
+
+<style>
+.users-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 24px;
+  margin: 32px 0 48px;
+}
+
+.user-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 28px 20px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  background: var(--vp-c-bg-soft);
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.user-card:hover {
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-bg-alt);
+}
+
+.user-logo-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 48px;
+}
+
+.user-logo {
+  max-height: 48px;
+  max-width: 160px;
+  object-fit: contain;
+  filter: grayscale(100%) brightness(0.9);
+  transition: filter 0.25s ease;
+}
+
+.user-card:hover .user-logo {
+  filter: grayscale(0%) brightness(1);
+}
+
+.user-name {
+  font-size: 13px;
+  color: var(--vp-c-text-2);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.user-name:hover {
+  color: var(--vp-c-brand-1);
+  text-decoration: underline;
+}
+</style>

--- a/docs/public/logos/README.md
+++ b/docs/public/logos/README.md
@@ -1,0 +1,26 @@
+# Logo Guidelines
+
+To add your organization's logo to the "Who's Using Cap" page:
+
+## Requirements
+
+- **Format**: SVG only
+- **Orientation**: Horizontal/landscape preferred
+- **Size**: The logo will be displayed at a max height of 48px and max width of 160px. Your SVG viewBox should reflect these proportions.
+- **Colors**: Any colors are fine — logos are displayed in grayscale by default and switch to full color on hover.
+- **Optimization**: Remove unnecessary metadata, comments, and minify paths. Tools like [SVGO](https://github.com/svg/svgo) can help.
+
+## How to Add
+
+1. Place your SVG file in this directory (`docs/public/logos/`)
+2. Add your entry to [`docs/.vitepress/theme/data/showcase.ts`](../.vitepress/theme/data/showcase.ts):
+   ```ts
+   {
+     name: 'Your Company',
+     logo: '/logos/your-company.svg',
+     url: 'https://your-company.com',
+   }
+   ```
+3. Open a pull request
+
+We'll review and merge. Thank you for supporting Cap!


### PR DESCRIPTION
## What
Adds a "Who's Using Cap" showcase page (`/guide/showcase.html`) listing organizations that trust Cap in production, with a "See all →" link on the landing page's trust section.

- New `docs/.vitepress/theme/data/showcase.ts` — TypeScript array with `ShowcaseEntry` interface
- New `docs/guide/showcase.md` — Grid page listing all organizations with grayscale→color hover
- New `docs/public/logos/README.md` — Logo contribution guidelines (SVG only, horizontal, 48px display height)
- Updated `HomeV2.vue` — "See all →" link below the 3 featured logos
- Updated `config.mjs` — Added to sidebar

<img height="200" alt="image" src="https://github.com/user-attachments/assets/58661396-fd3b-4ad0-b358-eec6b5368a6b" />

the page:

<img height="200" alt="image" src="https://github.com/user-attachments/assets/a4d5cc1e-2cf1-4a35-ac38-0da34b557c41" />


## Why
Closes #279. Provides social proof for potential adopters and gives the community an easy way to contribute (add SVG + one entry in the array).

## How to add your org
1. Drop an SVG in `docs/public/logos/`
2. Add an entry to `docs/.vitepress/theme/data/showcase.ts`
3. Open a PR


💘 Generated with Crush