### PR TITLE
Fix REDIS_PREFIX breaking standalone mode by prefixing HMSET keys

### DIFF
--- a/standalone/src/db.js
+++ b/standalone/src/db.js
@@ -29,6 +29,7 @@ const KEY_FIRST = new Set([
   "sismember",
   "hget",
   "hset",
+  "hmset",
   "hmget",
   "hgetall",
   "hincrby",


### PR DESCRIPTION
Fixes #275

### Problem
Setting `REDIS_PREFIX` breaks standalone mode: the Sites dashboard hangs on loading and sites never appear.

### Fix
Add `hmset` to `KEY_FIRST` so its key argument is prefixed consistently, exactly like `hset`/`hmget`.