### PR TITLE
fix(standalone): prefix hmset keys

### DIFF
--- a/standalone/src/db.js
+++ b/standalone/src/db.js
@@ -29,6 +29,7 @@ const KEY_FIRST = new Set([
   "sismember",
   "hget",
   "hset",
+  "hmset",
   "hmget",
   "hgetall",
   "hincrby",

--- a/standalone/test/db-prefix.test.js
+++ b/standalone/test/db-prefix.test.js
@@ -1,0 +1,30 @@
+import { afterAll, expect, test } from "bun:test";
+import { RedisClient } from "bun";
+
+const REDIS_URL =
+  process.env.REDIS_URL || process.env.VALKEY_URL || "redis://127.0.0.1:6379";
+const prefix = `cap-prefix-test:${crypto.randomUUID()}:`;
+const key = "key:metadata";
+
+process.env.REDIS_URL = REDIS_URL;
+process.env.REDIS_PREFIX = prefix;
+
+const raw = new RedisClient(REDIS_URL);
+await raw.send("PING", []);
+
+const { db } = await import("../src/db.js");
+
+afterAll(async () => {
+  await raw.send("DEL", [`${prefix}${key}`]);
+  raw.close();
+});
+
+test("prefixes hmset key metadata", async () => {
+  await db.hmset(key, ["name", "Example", "created", "1"]);
+
+  await expect(db.hmget(key, ["name", "created"])).resolves.toEqual([
+    "Example",
+    "1",
+  ]);
+  await expect(raw.exists(`${prefix}${key}`)).resolves.toBe(true);
+});


### PR DESCRIPTION
## Summary
- Prefix `hmset` keys through the standalone Redis adapter.
- Add a regression test for hash metadata written with `REDIS_PREFIX`.

## Problem
The standalone key-creation route writes metadata with `db.hmset(...)`, but `hmset` was missing from `KEY_FIRST`. When `REDIS_PREFIX` is configured, the key index is prefixed while the metadata hash is not. The dashboard can list the key but opening it returns `Key not found`.

## Validation
- `bun test test/db-prefix.test.js` with Bun 1.3.14 and Valkey