### PR TITLE
fix(standalone): add missing siteKey to server verification snippet

### DIFF
--- a/standalone/public/js/dashboard.js
+++ b/standalone/public/js/dashboard.js
@@ -310,7 +310,7 @@ function renderIntegrationTab(key) {
 <!-- pin a version in production, e.g. @cap.js/widget@3 -->
 
 <cap-widget data-cap-api-endpoint="${endpoint}"></cap-widget>`;
-  const nodeSnippet = `const res = await fetch("${origin}/siteverify", {
+  const nodeSnippet = `const res = await fetch("${origin}/${sk}/siteverify", {
   method: "POST",
   headers: { "content-type": "application/json" },
   body: JSON.stringify({ secret: process.env.CAP_SECRET, response: token }),


### PR DESCRIPTION
Add missing siteKey to server verification snippet

<img width="751" height="518" alt="image" src="https://github.com/user-attachments/assets/66ed51cf-da54-4e24-ac18-47cd6ed5c43e" />

<img width="815" height="506" alt="image" src="https://github.com/user-attachments/assets/29d621ba-c21e-44a5-9778-9fc252260be9" />
